### PR TITLE
Improve ramcar pursuit reliability

### DIFF
--- a/traffic_server.lua
+++ b/traffic_server.lua
@@ -224,33 +224,31 @@ end
 setTimer(function()
 --checa se não tem ninguém perto do veiculo, se não tem, apaga ele
             for i, vehi in ipairs(getElementsByType("vehicle")) do
-				if getElementData(vehi, "type") == "traffic" then
-					-- skip vehicles that explicitly disabled the traffic AI (rammer test vehicles)
-					if getElementData(vehi, "traffic_enabled") == false then
-						goto continue_vehicle_cleanup
-					end
-					contajogadores = 0
-					local deucerto = 0
-					for i, players in ipairs(getElementsByType("player")) do
-						contajogadores = contajogadores + 1
+                                if getElementData(vehi, "type") == "traffic" then
+                                        -- skip vehicles that explicitly disabled the traffic AI (rammer test vehicles)
+                                        if getElementData(vehi, "traffic_enabled") ~= false then
+                                                contajogadores = 0
+                                                local deucerto = 0
+                                                for i, players in ipairs(getElementsByType("player")) do
+                                                        contajogadores = contajogadores + 1
                         --outputChatBox("tentando apagar")
-						x, y, z = getElementPosition(players)
-						xp, yp, zp = getElementPosition(vehi)
-						if getDistanceBetweenPoints2D(x, y, xp, yp) > 90 then
-							deucerto = deucerto + 1
+                                                        x, y, z = getElementPosition(players)
+                                                        xp, yp, zp = getElementPosition(vehi)
+                                                        if getDistanceBetweenPoints2D(x, y, xp, yp) > 90 then
+                                                                deucerto = deucerto + 1
                             --outputChatBox("testei")
-						end
-					end
-					if deucerto >= contajogadores then
-						--outputChatBox("distancia correta:"..deucerto)
-						--outputChatBox("numero de jogadores:"..contajogadores)
-						destroyElement(vehi)
-						--outputChatBox("veh deleted")
-					end
-				end
-			end
-		::continue_vehicle_cleanup::
-end, 100, 0)
+                                                        end
+                                                end
+                                                if deucerto >= contajogadores then
+                                                        --outputChatBox("distancia correta:"..deucerto)
+                                                        --outputChatBox("numero de jogadores:"..contajogadores)
+                                                        destroyElement(vehi)
+                                                        --outputChatBox("veh deleted")
+                                                end
+                                        end
+                                end
+                        end
+        end, 100, 0)
 
 setTimer(function()
 --checa se não tem ninguém perto do pedestre, se não tem, apaga ele


### PR DESCRIPTION
## Summary
- allow `/ramcar` to remove an existing test vehicle and clean it up when the owner disconnects
- extend the rammer's pursuit persistence with multi-height LOS checks to keep tracking targets over hills
- add stuck detection and automatic reverse manoeuvres to free ramcars that get wedged in the world

## Testing
- `luac -p test_ramcar.lua` *(fails: tool not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e066a5348332a9c5bd030588bd10