### PR TITLE
Clear horn timers when peds are destroyed or reinitialized

### DIFF
--- a/traffic_client.lua
+++ b/traffic_client.lua
@@ -90,9 +90,11 @@ addEventHandler ( VEH_CREATED, _root, function ( node, next )
 end )
 
 addEventHandler ( "onClientElementDestroy", getResourceRootElement(), function()
-	if ( _peds[source] ) then
-		_peds[source] = nil
-	end
+        if ( _peds[source] ) then
+                _peds[source] = nil
+                HORN_STARTTIME[source] = nil
+                HORN_STARTTIMELONG[source] = nil
+        end
 end )
 
 function pedProcessSyncer ( ped )

--- a/traffic_processor.lua
+++ b/traffic_processor.lua
@@ -6,7 +6,10 @@ DISTANCE_NODEREMOVE = 6
 CURVE_INTERPOLATION = 45
 
 function pedInitialize ( ped, node, next )
-	_peds[ped] = {}
+        HORN_STARTTIME[ped] = nil
+        HORN_STARTTIMELONG[ped] = nil
+
+        _peds[ped] = {}
 	_peds[ped].panic = false
 	_peds[ped].sync = false
 	_peds[ped].queue = {}


### PR DESCRIPTION
## Summary
- clear HORN_STARTTIME and HORN_STARTTIMELONG entries when traffic peds are destroyed on the client
- reset horn timer bookkeeping during ped reinitialization before reusing handles

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5e824895883328f308227b86fca83