### PR TITLE
Register traffic client events during definitions load

### DIFF
--- a/definitions.lua
+++ b/definitions.lua
@@ -61,6 +61,17 @@ SPEED_TURNING = {
 VEH_CREATED = "v_1"
 VEH_REWARP = "v_2"
 
+-- Ensure custom events are registered before any server-side triggers run.
+-- When the resource is (re)started the server can immediately trigger
+-- VEH_CREATED for connected players.  If the client hasn't called addEvent
+-- yet, the trigger fails with "event not added clientside" and the spawned
+-- traffic vehicles never begin processing.  Registering the events here keeps
+-- them available as soon as the shared definitions are loaded.
+if addEvent then
+	addEvent(VEH_CREATED, true)
+	addEvent(VEH_REWARP, true)
+end
+
 if ( getLocalPlayer ) then
 	addCommandHandler("toggledebug", function()
 		DEBUG = not DEBUG


### PR DESCRIPTION
## Summary
- register the clientside traffic events when definitions.lua loads so they exist before the server triggers them
- prevent the v_1 not registered error that left traffic vehicles idle after spawning

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5fb32ee288332aa96ac59f26ee789